### PR TITLE
Add gcloud_component beta to compute-ssh action

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ jobs:
     - id: 'compute-ssh'
       uses: 'google-github-actions/ssh-compute@v2'
       with:
+        gcloud_component: beta # until WIF SSH is GA
         instance_name: 'example-instance'
         zone: 'us-central1-a'
         ssh_private_key: '${{ secrets.GCP_SSH_PRIVATE_KEY }}'


### PR DESCRIPTION
Added required gcloud_component parameter to WIF SSH action.

Otherwise you get this error:

> ERROR: gcloud crashed (NotImplementedError): SSH using federated workforce identities is not yet generally available (GA). Please use `gcloud beta compute ssh` to SSH using a third-party identity.